### PR TITLE
added suitable version string

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,3 +1,4 @@
+version: "2.4"
 services:
   db:
     image: mysql


### PR DESCRIPTION
On Linux I got complaints from docker-compose about invalid format of the docker-compose.yaml.
This was fixed by adding a suitable version string.